### PR TITLE
Protractor Sharding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# test results
+results.json
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm module downloads per month](http://img.shields.io/npm/dm/jasmine-bamboo-reporter.svg?style=flat)](https://www.npmjs.org/package/jasmine-bamboo-reporter)
 [![Dependency status](https://david-dm.org/voidberg/jasmine-bamboo-reporter.svg?style=flat)](https://david-dm.org/voidberg/jasmine-bamboo-reporter)
 
-> A reporter for Jasmine which produces a report compatible with Atlassian Bamboo Mocha Test Parser.
+> A reporter for Jasmine which produces a report compatible with Atlassian Bamboo Mocha Test Parser. It supports 'test sharding' or multiple instances of Jasmine running via Protractor. This support is handled by locking the results file and then merging with any previous results.
 
 ## Installation
 
@@ -21,16 +21,36 @@ jasmine.getEnv().addReporter(new JSONReporter({
 	beautify: true,
 	indentationLevel: 4 // used if beautify === true
 }));
+
+//ensure there are no lock files and no previous results to merge against.
+if (fs.existsSync("jasmine-results.json.lock")) fs.unlinkSync("jasmine-results.json.lock");
+if (fs.existsSync("jasmine-results.json")) fs.unlinkSync("jasmine-results.json");
+
 ```
 
 ### Protractor/Jasmine Usage
 ```javascript
 // in Protractor conf
 var JSONReporter = require('jasmine-bamboo-reporter');
+var fs = require('fs');
+
+exports.config = {
+
+framework: 'jasmine2',
 
 ...
 
-framework: 'jasmine2',
+beforeLaunch: function () {
+    //clean up any residual/leftover from a previous run. Ensure we have clean
+    //files for both locking and merging.
+    if (fs.existsSync('jasmine-results.json.lock')) {
+      fs.unlinkSync('jasmine-results.json.lock');
+    }
+    if (fs.existsSync('jasmine-results.json')) {
+      fs.unlink('jasmine-results.json');
+    }
+},
+  
 onPrepare: function() {
 	jasmine.getEnv().addReporter(new JSONReporter({
 		file: 'jasmine-results.json', // by default it writes to jasmine.json

--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
+
+"use strict";
 var fs = require('fs');
+var lockFile = require('lockfile');
+
 
 function format(result) {
   var formatted = '';
@@ -35,23 +39,26 @@ function shallowMerge(obj1, obj2) {
   return mergedObj;
 }
 
-function reporter(opts) {
+function Reporter(opts) {
   var defaultOpts = {
     file: 'jasmine.json',
     beautify: true,
     indentationLevel: 4,
   };
-  var options = shallowMerge(defaultOpts, typeof opts === 'object' ? opts : {});
-  var spec = {};
-  var specStart;
-  var output = {
+  this.options = shallowMerge(defaultOpts, typeof opts === 'object' ? opts : {});
+
+  this.spec = {};
+  this.specStart;
+  this.output = {
     stats: {
       suites: 0,
       tests: 0,
+
       passes: 0,
       pending: 0,
       failures: 0,
-      start: 0,
+
+      start: 0, // this is the overall time for everything. - all suites.
       end: 0,
       duration: 0,
     },
@@ -59,50 +66,103 @@ function reporter(opts) {
     passes: [],
     skipped: [],
   };
-
-  this.suiteDone = function suiteDone() {
-    output.stats.suites++;
-  };
-
-  this.specStarted = function specStarted() {
-    specStart = new global.Date();
-  };
-
-  this.specDone = function specDone(result) {
-    spec.duration = Math.floor((new global.Date().getTime() - specStart.getTime()) / 1000);
-    spec.title = result.fullName;
-    spec.fullTitle = result.description;
-
-    output.stats.tests++;
-
-    if (result.status === 'passed') {
-      output.stats.passes++;
-      output.passes.push(spec);
-    } else if (result.status === 'failed') {
-      output.stats.failures++;
-      spec.error = format(result);
-      output.failures.push(spec);
-    } else {
-      output.stats.pending++;
-      output.skipped.push(spec);
-    }
-
-    spec = {};
-  };
-
-  this.jasmineStarted = function jasmineStarted() {
-    output.stats.start = new global.Date();
-  };
-
-  this.jasmineDone = function jasmineDone() {
-    var resultsOutput;
-    output.stats.end = new global.Date();
-    output.stats.duration = Math.floor((output.stats.end.getTime() - output.stats.start.getTime()) / 1000);
-
-    resultsOutput = options.beautify ? JSON.stringify(output, null, options.indentationLevel) : JSON.stringify(output);
-
-    fs.writeFileSync(options.file, resultsOutput);
-  };
 }
 
-module.exports = reporter;
+Reporter.prototype.suiteDone = function() {
+  this.output.stats.suites++;
+};
+
+Reporter.prototype.specStarted = function() {
+  this.specStart = new global.Date();
+};
+
+Reporter.prototype.specDone = function(result) {
+  this.spec.duration = Math.floor((new global.Date().getTime() - this.specStart.getTime()) / 1000);
+  this.spec.title = result.fullName;
+  this.spec.fullTitle = result.description;
+
+  this.output.stats.tests++;
+
+  if (result.status === 'passed') {
+    this.output.stats.passes++;
+    this.output.passes.push(this.spec);
+  } else if (result.status === 'failed') {
+    this.output.stats.failures++;
+    this.spec.error = format(result);
+    this.output.failures.push(this.spec);
+  } else {
+    this.output.stats.pending++;
+    this.output.skipped.push(this.spec);
+  }
+
+  this.spec = {};
+};
+
+Reporter.prototype.jasmineStarted = function() {
+  this.output.stats.start = new global.Date();
+};
+
+Reporter.prototype.mergeOutput = function (previous) {
+  this.output.stats.suites = this.output.stats.suites + previous.stats.suites;
+  this.output.stats.tests = this.output.stats.tests + previous.stats.tests;
+
+  this.output.stats.passing = this.output.stats.passing + previous.stats.passing;
+  this.output.stats.pending = this.output.stats.pending + previous.stats.pending;
+  this.output.stats.failures = this.output.stats.failures + previous.stats.failures;
+
+  this.output.start = previous.start;
+  // retain output.end from this run, not the previous run.
+  // math on duration will be computed elsewhere
+  this.output.failures = this.output.failures.concat(previous.failures);
+  this.output.passes = this.output.passes.concat(previous.passes);
+  this.output.skipped = this.output.skipped.concat(previous.skipped);
+};
+
+
+// jasmineDone gets called multiple times, once for each process (thread) we are executing. Normally this would
+// just be one thread, but protractor can "shard" tests which really just runs multiple processes with one
+// to rule them all.
+//
+// Since that code is running in separate processes, it isn't easy to use a global/static class variable to
+// handle a single instance of the jasmine reporter - nor is it easy to aggregate the results. So the trick here
+// is to lock, read any file that exists, merge, write results to file, and then release lock.
+Reporter.prototype.jasmineDone = function() {
+  var self = this;
+  var resultsOutput;
+  var lockname = this.options.file + '.lock';
+  var previous;
+  var raw;
+
+  self.output.stats.end = new global.Date();
+
+
+  lockFile.lock(lockname, {wait: 2000}, function postLock(er) {
+    if (er) {
+      /* eslint-disable no-console */
+      console.error('Jasmine bamboo reporter unable to acquire a file lock for ' + lockname);
+      /* eslint-enable no-console */
+      return;
+    }
+    // we can ensure that no other process will update the results causing a write-afte-read hazard.
+
+    if (fs.existsSync(self.options.file)) {
+      raw = fs.readFileSync(self.options.file, {encoding: 'utf8'});
+      previous = JSON.parse(raw);
+      debugger;
+
+      self.mergeOutput(previous);
+    }
+    self.output.stats.duration = Math.floor((self.output.stats.end.getTime() - self.output.stats.start.getTime()) / 1000);
+    resultsOutput = self.options.beautify ? JSON.stringify(self.output, null, self.options.indentationLevel) : JSON.stringify(self.output);
+    fs.writeFileSync(self.options.file, resultsOutput);
+    lockFile.unlock(lockname, function postUnlock(erUnlock) {
+      if (erUnlock) {
+        /* eslint-disable no-console */
+        console.error('Jasmine bamboo reporter could not unlock file ' + lockname);
+        /* eslint-enable no-console */
+      }
+    });
+  });
+};
+
+module.exports = Reporter;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-
-"use strict";
 var fs = require('fs');
 var lockFile = require('lockfile');
 
@@ -48,7 +46,7 @@ function Reporter(opts) {
   this.options = shallowMerge(defaultOpts, typeof opts === 'object' ? opts : {});
 
   this.spec = {};
-  this.specStart;
+  this.specStart = 0;
   this.output = {
     stats: {
       suites: 0,
@@ -68,15 +66,15 @@ function Reporter(opts) {
   };
 }
 
-Reporter.prototype.suiteDone = function() {
+Reporter.prototype.suiteDone = function suiteDone() {
   this.output.stats.suites++;
 };
 
-Reporter.prototype.specStarted = function() {
+Reporter.prototype.specStarted = function specStarted() {
   this.specStart = new global.Date();
 };
 
-Reporter.prototype.specDone = function(result) {
+Reporter.prototype.specDone = function specDone(result) {
   this.spec.duration = Math.floor((new global.Date().getTime() - this.specStart.getTime()) / 1000);
   this.spec.title = result.fullName;
   this.spec.fullTitle = result.description;
@@ -98,11 +96,11 @@ Reporter.prototype.specDone = function(result) {
   this.spec = {};
 };
 
-Reporter.prototype.jasmineStarted = function() {
+Reporter.prototype.jasmineStarted = function jasmineStarted() {
   this.output.stats.start = new global.Date();
 };
 
-Reporter.prototype.mergeOutput = function (previous) {
+Reporter.prototype.mergeOutput = function mergeOutput(previous) {
   this.output.stats.suites = this.output.stats.suites + previous.stats.suites;
   this.output.stats.tests = this.output.stats.tests + previous.stats.tests;
 
@@ -126,7 +124,7 @@ Reporter.prototype.mergeOutput = function (previous) {
 // Since that code is running in separate processes, it isn't easy to use a global/static class variable to
 // handle a single instance of the jasmine reporter - nor is it easy to aggregate the results. So the trick here
 // is to lock, read any file that exists, merge, write results to file, and then release lock.
-Reporter.prototype.jasmineDone = function() {
+Reporter.prototype.jasmineDone = function jasmineDone() {
   var self = this;
   var resultsOutput;
   var lockname = this.options.file + '.lock';
@@ -148,8 +146,6 @@ Reporter.prototype.jasmineDone = function() {
     if (fs.existsSync(self.options.file)) {
       raw = fs.readFileSync(self.options.file, {encoding: 'utf8'});
       previous = JSON.parse(raw);
-      debugger;
-
       self.mergeOutput(previous);
     }
     self.output.stats.duration = Math.floor((self.output.stats.end.getTime() - self.output.stats.start.getTime()) / 1000);

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ function Reporter(opts) {
       start: 0, // this is the overall time for everything. - all suites.
       end: 0,
       duration: 0,
+      time: 0, // bamboo + mocha seem to be using "time", not duration.
     },
     failures: [],
     passes: [],
@@ -76,6 +77,7 @@ Reporter.prototype.specStarted = function specStarted() {
 
 Reporter.prototype.specDone = function specDone(result) {
   this.spec.duration = Math.floor((new global.Date().getTime() - this.specStart.getTime()) / 1000);
+  this.spec.time = this.spec.duration;
   this.spec.title = result.fullName;
   this.spec.fullTitle = result.description;
 
@@ -149,6 +151,7 @@ Reporter.prototype.jasmineDone = function jasmineDone() {
       self.mergeOutput(previous);
     }
     self.output.stats.duration = Math.floor((self.output.stats.end.getTime() - self.output.stats.start.getTime()) / 1000);
+    self.output.stats.time = self.output.stats.duration;
     resultsOutput = self.options.beautify ? JSON.stringify(self.output, null, self.options.indentationLevel) : JSON.stringify(self.output);
     fs.writeFileSync(self.options.file, resultsOutput);
     lockFile.unlock(lockname, function postUnlock(erUnlock) {

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ Reporter.prototype.mergeOutput = function (previous) {
   this.output.stats.suites = this.output.stats.suites + previous.stats.suites;
   this.output.stats.tests = this.output.stats.tests + previous.stats.tests;
 
-  this.output.stats.passing = this.output.stats.passing + previous.stats.passing;
+  this.output.stats.passes = this.output.stats.passes + previous.stats.passes;
   this.output.stats.pending = this.output.stats.pending + previous.stats.pending;
   this.output.stats.failures = this.output.stats.failures + previous.stats.failures;
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,14 @@
   },
   "readmeFilename": "README.md",
   "dependencies": {
+    "fs": "0.0.2",
+    "lockfile": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^1.5.1",
-    "eslint-config-airbnb": "^0.1.0"
+    "eslint-config-airbnb": "^0.1.0",
+    "sleep": "^3.0.1",
+    "jasmine": "^2.4.1"
+
   }
 }

--- a/spec/children/allFail.js
+++ b/spec/children/allFail.js
@@ -1,0 +1,5 @@
+describe("fail suite 1", function () {
+  it("should like lima beans", function () { expect(false).toBeTruthy(); } );
+  it("should be respectful to its elders", function () { expect(false).toBeTruthy(); } );
+  it("should like Donald Trump", function () { expect(false).toBeTruthy(); } );
+});

--- a/spec/children/allPass.js
+++ b/spec/children/allPass.js
@@ -1,0 +1,15 @@
+describe("pass suite 1", function () {
+  it("should pass once", function () { expect(true).toBeTruthy; } );
+  it("should pass twice", function () { expect(true).toBeTruthy; } );
+  it("should pass thrice", function () { expect(true).toBeTruthy; } );
+  it("should pass mice", function () { expect(true).toBeTruthy; } );
+  it("should pass lice", function () { expect(true).toBeTruthy; } );
+  it("should pass dice", function () { expect(true).toBeTruthy; } );
+  it("should pass septa-ice", function () { expect(true).toBeTruthy; } );
+});
+
+describe("pass suite 2", function () {
+  it("should pass octopus", function () { expect(true).toBeTruthy; } );
+  it("should pass eat sushi", function () { expect(true).toBeTruthy; } );
+  it("should visit thailand", function () { expect(true).toBeTruthy; } );
+});

--- a/spec/children/jasmineRunner.js
+++ b/spec/children/jasmineRunner.js
@@ -1,0 +1,16 @@
+#!/usr/bin/node
+
+// This runs a jasmine test with a custom reporter (the one we're trying to test)
+var Jasmine = require('jasmine');
+var jasmine = new Jasmine();
+
+var JSONReporter = require('../../index');
+var reporter = new JSONReporter({
+  file: 'results.json',
+  beautify: true,
+  indentationLevel: 4
+});
+
+jasmine.addReporter(reporter);
+console.log("Running test " + process.argv[2]);
+jasmine.execute([process.argv[2]]);

--- a/spec/children/singletonSpec.js
+++ b/spec/children/singletonSpec.js
@@ -1,0 +1,43 @@
+var sleep = require('sleep');
+
+describe("singleton suite 1", function () {
+  it("should pass", function () {
+    expect(true).toBeTruthy("true should be true");
+    sleep.sleep(1);
+  });
+  it("should fail", function () {
+    sleep.sleep(2);
+    expect(false).toBeTruthy("false should not be true. This will fail");
+  });
+  xit("should defer", function () {
+    expect(false).toBeTruthy("false should not be true. This will fail");
+    sleep.sleep(10); // this won't trigger.
+  });
+
+});
+
+describe("singleton suite 2", function () {
+  it("none shall fail", function () {
+    expect(true).toBeTruthy("true should be true");
+  });
+  it("should like monty python", function () {
+    expect(true).toBeTruthy("true should be true");
+  });
+  it("should like Torchwood", function () {
+    expect(true).toBeTruthy("true should be true");
+    sleep.sleep(2);
+  });
+  it("should like watching Barbie", function () {
+    // this one is a stretch
+    expect(true).toBeTruthy("true should be true");
+    sleep.sleep(4);
+  });
+
+});
+
+xdescribe("singleton suite 3", function () {
+  xit("none shall fail", function () {
+    expect(true).toBeTruthy("true should be true");
+  });
+
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/spec/testSpec.js
+++ b/spec/testSpec.js
@@ -21,6 +21,7 @@ function checkStruct(json) {
     'start': false,
     'end': false,
     'duration': false,
+    'time': false
   }
 
   Object.keys(json).forEach(function (key) {
@@ -37,6 +38,7 @@ function checkStruct(json) {
       expected_stats[key] = true;
     }
   });
+  expect(json.stats.duration).toBe(json.stats.time, "Want time == duration");
 
   Object.keys(expected).forEach(function (key) {
     expect(expected[key]).toBeTruthy("Should see key " + key);
@@ -44,6 +46,7 @@ function checkStruct(json) {
   Object.keys(expected_stats).forEach(function (key) {
     expect(expected_stats[key]).toBeTruthy("Should see key stats." + key);
   });
+
 
 }
 

--- a/spec/testSpec.js
+++ b/spec/testSpec.js
@@ -1,0 +1,142 @@
+"use strict";
+var fs = require ('fs');
+const cp = require('child_process');
+
+// this ensures that I have the output struct AND ONLY THE OUTPUT STRUCT.
+// I had an error where I added passing+passing instead of passes+passes.
+function checkStruct(json) {
+  var expected = {
+    'stats' : false,
+    'failures': false,
+    'passes': false,
+    'skipped': false
+  };
+
+  var expected_stats = {
+    'suites': false,
+    'tests': false,
+    'passes': false,
+    'pending': false,
+    'failures': false,
+    'start': false,
+    'end': false,
+    'duration': false,
+  }
+
+  Object.keys(json).forEach(function (key) {
+    if (typeof expected[key] === 'undefined') {
+      expect(false).toBeTruthy("found an unexpected key: " + key);
+    } else {
+      expected[key] = true;
+    }
+  });
+  Object.keys(json.stats).forEach(function (key) {
+    if (typeof expected_stats[key] === 'undefined') {
+      expect(false).toBeTruthy("found an unexpected key: stats." + key);
+    } else {
+      expected_stats[key] = true;
+    }
+  });
+
+  Object.keys(expected).forEach(function (key) {
+    expect(expected[key]).toBeTruthy("Should see key " + key);
+  });
+  Object.keys(expected_stats).forEach(function (key) {
+    expect(expected_stats[key]).toBeTruthy("Should see key stats." + key);
+  });
+
+}
+
+
+describe("jasmine tests", function () {
+  beforeEach(function () {
+    if (fs.existsSync("results.json.lock")) fs.unlinkSync("results.json.lock");
+    if (fs.existsSync("results.json")) fs.unlinkSync("results.json");
+  });
+
+  it("should collect statistics for a single thread", function () {
+    cp.execSync("spec/children/jasmineRunner.js spec/children/singletonSpec.js");
+    expect(fs.existsSync("results.json")).toBeTruthy("Should see a results.json");
+    expect(fs.existsSync("results.json.lock")).toBeFalsy("Should not see a lockfile");
+
+    var raw = fs.readFileSync("results.json", {encoding: 'utf8'});
+    var data = JSON.parse(raw);
+
+    checkStruct(data);
+
+    expect(data.stats.suites).toBe(3);
+    expect(data.stats.passes).toBe(5);
+    expect(data.stats.failures).toBe(1, "Want 1 failure");
+    expect(data.stats.pending).toBe(2);
+    expect(data.stats.duration).toBe(9);
+    expect(data.failures[0].duration).toBe(2);
+    expect(data.failures.length).toBe(1);
+    expect(data.passes[4].duration).toBe(4);
+    expect(data.passes[4].fullTitle).toBe("should like watching Barbie");
+    expect(data.passes.length).toBe(5);
+
+    expect(data.skipped.length).toBe(2);
+  });
+
+  it("should handle 4 tests finishing concurrently", function (done) {
+    var child = [];
+    var complete = 0;
+    for (var i=0;i<4;i++) {
+
+      child[i] = cp.exec("spec/children/jasmineRunner.js spec/children/singletonSpec.js",
+                         function (error, stdout, stderr) {
+                           complete++;
+                           if (complete == 4) {
+                             var raw = fs.readFileSync("results.json", {encoding: 'utf8'});
+                             var data = JSON.parse(raw);
+                             checkStruct(data);
+                             expect(data.stats.suites).toBe(12);
+                             expect(data.stats.passes).toBe(20);
+                             expect(data.stats.duration).toBeGreaterThan(8);
+                             expect(data.stats.duration).toBeLessThan(10);
+                             expect(data.passes.length).toBe(20);
+                             expect(data.skipped.length).toBe(8);
+                             expect(data.failures.length).toBe(4);
+
+                             done(); //necessary because I'm all Asynch on this puppy.
+                           }
+                         });
+    }
+
+    /*    waitForChildren(child);
+
+          for (var i=0;i<4;i++) {
+          waitpid(child[i].pid);
+          }
+
+    */
+  }, 20000);
+
+  it("should blend all passes with all fails", function () {
+    cp.execSync("spec/children/jasmineRunner.js spec/children/allPass.js");
+    cp.execSync("spec/children/jasmineRunner.js spec/children/allFail.js");
+
+    var raw = fs.readFileSync("results.json", {encoding: 'utf8'});
+    var data = JSON.parse(raw);
+    checkStruct(data);
+    expect(data.stats.suites).toBe(3);
+    expect(data.stats.passes).toBe(10);
+    expect(data.stats.failures).toBe(3);
+    expect(data.stats.duration).toBeLessThan(2);
+
+  });
+
+
+});
+
+// we should write these too. But I'm lazy right now.
+xdescribe("output tests", function () {
+  xit("should beautify output when requested", function () {
+  });
+
+  xit("should handle 2, 3, or 4 character spacing", function () {
+  });
+
+  xit("should allow tabs in lieu of spaces", function () {
+  });
+});


### PR DESCRIPTION
it("This PR should", function() {
- handle a sharded or multi-threaded result set - E.g. what protractor does when you set shardTestFiles + maxInstances in capabilities. This is accomplished by reading the result file and merging with it. There is an additional lock to prevent shards that complete close in time from having a write-after-read hazard. (e.g. read, read, write, write).  Unfortunately this can't be accomplished with a global variable/sempahore/internal instance count since those protractor instances are forked with their own jasmine instances. 
- add tests for basic functionality (and add some tests to be written later because I'm lazy)
- converts the basic object to more of a class so I can call subroutines within the class. Frankly, I'm still new at JS, so if there's a better way???

});
